### PR TITLE
from torch.nn.utils.spectral_norm import SpectralNorm

### DIFF
--- a/networks.py
+++ b/networks.py
@@ -6,6 +6,7 @@ from torch import nn
 from torch.autograd import Variable
 import torch
 import torch.nn.functional as F
+from torch.nn.utils.spectral_norm import SpectralNorm
 from torchvision import models
 from utils import weights_init
 


### PR DESCRIPTION
For access to __SpectralNorm()__ on line 578.
* https://github.com/pytorch/pytorch/blob/master/torch/nn/utils/spectral_norm.py

[flake8](http://flake8.pycqa.org) testing of https://github.com/NVlabs/DG-Net on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./utils.py:229:18: F821 undefined name 'load_lua'
        vgglua = load_lua(os.path.join(model_dir, 'vgg16.t7'))
                 ^
./utils.py:230:15: F821 undefined name 'Vgg16'
        vgg = Vgg16()
              ^
./utils.py:234:11: F821 undefined name 'Vgg16'
    vgg = Vgg16()
          ^
./networks.py:577:25: F821 undefined name 'SpectralNorm'
            self.conv = SpectralNorm(nn.Conv2d(input_dim, output_dim, kernel_size, stride, dilation=dilation, bias=self.use_bias))
                        ^
4     F821 undefined name 'SpectralNorm'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree